### PR TITLE
Add ISMAH mod compatibility for armor rendering

### DIFF
--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -38,6 +38,7 @@ dependencies {
 
     modImplementation "maven.modrinth:cosmetic-armor-revitalized-fabric:1.7.0"
     modImplementation "dev.emi:trinkets:3.10.0"
+    modImplementation "maven.modrinth:ismah:uB2MkEJy"
 }
 
 loom {

--- a/fabric/src/main/java/org/dawnoftime/armoroftheages/ArmorOfTheAgesFabric.java
+++ b/fabric/src/main/java/org/dawnoftime/armoroftheages/ArmorOfTheAgesFabric.java
@@ -1,5 +1,7 @@
 package org.dawnoftime.armoroftheages;
 
+import com.github.razorplay01.ismah.client.ISMAHClient;
+import com.github.razorplay01.ismah.client.api.ArmorRendererRegistry;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.itemgroup.v1.FabricItemGroup;
 import net.fabricmc.loader.api.FabricLoader;
@@ -10,6 +12,7 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import org.dawnoftime.armoroftheages.compat.ISMAHCompat;
 import org.dawnoftime.armoroftheages.networking.FabricConfigSyncNetworkHandler;
 
 import static org.dawnoftime.armoroftheages.AotAItemRegistry.ITEMS;
@@ -36,5 +39,10 @@ public class ArmorOfTheAgesFabric implements ModInitializer {
         Registry.register(BuiltInRegistries.CREATIVE_MODE_TAB, ResourceLocation.fromNamespaceAndPath(MOD_ID, MOD_ID), CREATIVE_MODE_TAB);
 
         CommonClass.init();
+
+        if (FabricLoader.getInstance().isModLoaded("ismah")) {
+            ArmorRendererRegistry.register(new ISMAHCompat());
+            ISMAHClient.LOGGER.info("ISMAH detected. Registering ISMAHCompat.");
+        }
     }
 }

--- a/fabric/src/main/java/org/dawnoftime/armoroftheages/compat/ISMAHCompat.java
+++ b/fabric/src/main/java/org/dawnoftime/armoroftheages/compat/ISMAHCompat.java
@@ -1,0 +1,73 @@
+package org.dawnoftime.armoroftheages.compat;
+
+import com.github.razorplay01.ismah.client.api.CustomArmorRenderer;
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.model.HumanoidModel;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.texture.OverlayTexture;
+import net.minecraft.world.entity.HumanoidArm;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.ItemStack;
+import org.dawnoftime.armoroftheages.client.ArmorModelProvider;
+import org.dawnoftime.armoroftheages.client.models.ArmorModel;
+import org.dawnoftime.armoroftheages.item.HumanoidArmorItem;
+
+public class ISMAHCompat implements CustomArmorRenderer {
+    @Override
+    public boolean canRender(ItemStack stack) {
+        return stack.getItem() instanceof HumanoidArmorItem;
+    }
+
+    @Override
+    public void render(PoseStack poseStack, MultiBufferSource vertexConsumers, int light, ItemStack stack, HumanoidArm arm, HumanoidModel playerModel) {
+        if (!(stack.getItem() instanceof HumanoidArmorItem armorItem)) {
+            return;
+        }
+
+        ArmorModelProvider provider = armorItem.getModelProvider();
+        if (provider == null) {
+            return;
+        }
+
+        LivingEntity entity = Minecraft.getInstance().player;
+        ArmorModel<?> model = provider.getArmorModel(entity);
+        if (model == null) {
+            return;
+        }
+
+        model.copyEntityModelPosition(playerModel);
+        model.setupAnim(entity, 0.0F, 0.0F, 0.0F, entity.yHeadRot, entity.getXRot());
+
+        boolean originalRightArmVisible = model.rightArm.visible;
+        boolean originalLeftArmVisible = model.leftArm.visible;
+        boolean originalHeadVisible = model.head.visible;
+        boolean originalBodyVisible = model.body.visible;
+        boolean originalRightLegVisible = model.rightLeg.visible;
+        boolean originalLeftLegVisible = model.leftLeg.visible;
+
+        boolean isRightArm = arm == HumanoidArm.RIGHT;
+        model.rightArm.visible = isRightArm;
+        model.leftArm.visible = !isRightArm;
+        model.head.visible = false;
+        model.body.visible = false;
+        model.rightLeg.visible = false;
+        model.leftLeg.visible = false;
+
+        VertexConsumer vertexConsumer = vertexConsumers.getBuffer(RenderType.armorCutoutNoCull(provider.getTexture(entity)));
+        model.renderToBuffer(poseStack, vertexConsumer, light, OverlayTexture.NO_OVERLAY);
+
+        if (stack.hasFoil()) {
+            model.renderToBuffer(poseStack, vertexConsumers.getBuffer(RenderType.armorEntityGlint()), light, OverlayTexture.NO_OVERLAY);
+        }
+
+        model.rightArm.visible = originalRightArmVisible;
+        model.leftArm.visible = originalLeftArmVisible;
+        model.head.visible = originalHeadVisible;
+        model.body.visible = originalBodyVisible;
+        model.rightLeg.visible = originalRightLegVisible;
+        model.leftLeg.visible = originalLeftLegVisible;
+    }
+}

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -22,6 +22,17 @@ neoForge {
                 includeGroup "curse.maven"
             }
         }
+        exclusiveContent {
+            forRepository {
+                maven {
+                    name = "Modrinth"
+                    url = "https://api.modrinth.com/maven"
+                }
+            }
+            filter {
+                includeGroup "maven.modrinth"
+            }
+        }
     }
 
     runs {
@@ -56,4 +67,5 @@ dependencies {
 
 	implementation "thedarkcolour:kotlinforforge-neoforge:5.6.0"
     implementation ("dev.isxander:yet-another-config-lib:${project.yacl_version}-neoforge")
+    implementation "maven.modrinth:ismah:dvy2x8YW"
 }

--- a/neoforge/src/main/java/org/dawnoftime/armoroftheages/ArmorOfTheAges.java
+++ b/neoforge/src/main/java/org/dawnoftime/armoroftheages/ArmorOfTheAges.java
@@ -1,5 +1,7 @@
 package org.dawnoftime.armoroftheages;
 
+import com.github.razorplay01.ismah.client.ISMAHClient;
+import com.github.razorplay01.ismah.client.api.ArmorRendererRegistry;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.codec.StreamCodec;
@@ -7,6 +9,7 @@ import net.minecraft.world.item.CreativeModeTab;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.ModContainer;
+import net.neoforged.fml.ModList;
 import net.neoforged.fml.ModLoadingContext;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.fml.loading.FMLPaths;
@@ -15,6 +18,7 @@ import net.neoforged.neoforge.network.event.RegisterPayloadHandlersEvent;
 import net.neoforged.neoforge.network.registration.PayloadRegistrar;
 import net.neoforged.neoforge.registries.DeferredRegister;
 import org.dawnoftime.armoroftheages.client.ArmorOfTheAgesClientNeoforge;
+import org.dawnoftime.armoroftheages.compat.ISMAHCompat;
 import org.dawnoftime.armoroftheages.config.AOTAConfig;
 import org.dawnoftime.armoroftheages.networking.NeoforgeConfigSyncNetworkHandler;
 import org.dawnoftime.armoroftheages.networking.packets.C2SDisablePreferencesPacket;
@@ -30,7 +34,7 @@ import static org.dawnoftime.armoroftheages.AotAItemRegistry.TAB_ICON;
 public class ArmorOfTheAges {
     public static final DeferredRegister<CreativeModeTab> CREATIVE_MODE_TAB = DeferredRegister.create(Registries.CREATIVE_MODE_TAB, MOD_ID);
 
-    public ArmorOfTheAges(IEventBus modEventBus, ModContainer modContainer,Dist dist) {
+    public ArmorOfTheAges(IEventBus modEventBus, ModContainer modContainer, Dist dist) {
         CommonClass.CONFIG_SYNC_HANDLER = new NeoforgeConfigSyncNetworkHandler();
         Constants.CONFIG_PATH = FMLPaths.CONFIGDIR.get().resolve(MOD_ID + ".json");
 
@@ -61,6 +65,11 @@ public class ArmorOfTheAges {
         }
 
         CommonClass.init();
+
+        if (ModList.get().isLoaded("ismah")) {
+            ArmorRendererRegistry.register(new ISMAHCompat());
+            ISMAHClient.LOGGER.info("ISMAH detected. Registering ISMAHCompat.");
+        }
     }
 
     public void registerPackets(final RegisterPayloadHandlersEvent event) {

--- a/neoforge/src/main/java/org/dawnoftime/armoroftheages/compat/ISMAHCompat.java
+++ b/neoforge/src/main/java/org/dawnoftime/armoroftheages/compat/ISMAHCompat.java
@@ -1,0 +1,73 @@
+package org.dawnoftime.armoroftheages.compat;
+
+import com.github.razorplay01.ismah.client.api.CustomArmorRenderer;
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.model.HumanoidModel;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.texture.OverlayTexture;
+import net.minecraft.world.entity.HumanoidArm;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.ItemStack;
+import org.dawnoftime.armoroftheages.client.ArmorModelProvider;
+import org.dawnoftime.armoroftheages.client.models.ArmorModel;
+import org.dawnoftime.armoroftheages.item.HumanoidArmorItem;
+
+public class ISMAHCompat implements CustomArmorRenderer {
+    @Override
+    public boolean canRender(ItemStack stack) {
+        return stack.getItem() instanceof HumanoidArmorItem;
+    }
+
+    @Override
+    public void render(PoseStack poseStack, MultiBufferSource vertexConsumers, int light, ItemStack stack, HumanoidArm arm, HumanoidModel playerModel) {
+        if (!(stack.getItem() instanceof HumanoidArmorItem armorItem)) {
+            return;
+        }
+
+        ArmorModelProvider provider = armorItem.getModelProvider();
+        if (provider == null) {
+            return;
+        }
+
+        LivingEntity entity = Minecraft.getInstance().player;
+        ArmorModel<?> model = provider.getArmorModel(entity);
+        if (model == null) {
+            return;
+        }
+
+        model.copyEntityModelPosition(playerModel);
+        model.setupAnim(entity, 0.0F, 0.0F, 0.0F, entity.yHeadRot, entity.getXRot());
+
+        boolean originalRightArmVisible = model.rightArm.visible;
+        boolean originalLeftArmVisible = model.leftArm.visible;
+        boolean originalHeadVisible = model.head.visible;
+        boolean originalBodyVisible = model.body.visible;
+        boolean originalRightLegVisible = model.rightLeg.visible;
+        boolean originalLeftLegVisible = model.leftLeg.visible;
+
+        boolean isRightArm = arm == HumanoidArm.RIGHT;
+        model.rightArm.visible = isRightArm;
+        model.leftArm.visible = !isRightArm;
+        model.head.visible = false;
+        model.body.visible = false;
+        model.rightLeg.visible = false;
+        model.leftLeg.visible = false;
+
+        VertexConsumer vertexConsumer = vertexConsumers.getBuffer(RenderType.armorCutoutNoCull(provider.getTexture(entity)));
+        model.renderToBuffer(poseStack, vertexConsumer, light, OverlayTexture.NO_OVERLAY);
+
+        if (stack.hasFoil()) {
+            model.renderToBuffer(poseStack, vertexConsumers.getBuffer(RenderType.armorEntityGlint()), light, OverlayTexture.NO_OVERLAY);
+        }
+
+        model.rightArm.visible = originalRightArmVisible;
+        model.leftArm.visible = originalLeftArmVisible;
+        model.head.visible = originalHeadVisible;
+        model.body.visible = originalBodyVisible;
+        model.rightLeg.visible = originalRightLegVisible;
+        model.leftLeg.visible = originalLeftLegVisible;
+    }
+}


### PR DESCRIPTION
Introduces ISMAHCompat for both Fabric and NeoForge to support custom armor rendering when the ISMAH mod is present. Updates build scripts to include ISMAH as a dependency and registers the compatibility class if ISMAH is detected at runtime.